### PR TITLE
fix copyright statement in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Cory Guynn
+   Copyright (c) 2019 Cisco Systems, Inc. and/or its affiliates
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Note, the copyright statement in the NOTICE is correct.
This one in the LICENSE needs to be consistent, else it is confusing.